### PR TITLE
This basically is because we're going to use the "temporary" fonts for longer than we expected.

### DIFF
--- a/index.css
+++ b/index.css
@@ -18,8 +18,8 @@
   --text-size-step-6:  calc( var(--text-size-step-5)  * var(--scale-factor) );
   --text-size-step-7:  calc( var(--text-size-step-6)  * var(--scale-factor) );
 
-  --fontfamily-body: Halifax, Tahoma, sans-serif;
-  --fontfamily-display: Milo, Palatino, serif;
+  --fontfamily-body: 'Halifax Regular', Tahoma, sans-serif;
+  --fontfamily-display: 'FF Milo Serif Pro', Palatino, serif;
 
   --text-line-height-basic: 1.4;
 


### PR DESCRIPTION
I expected to add `@font-face` declarations earlier than this, but we have to push forward and have something usable.

When we have fonts, `@font-face` declarations will come and this will have to be changed.