### PR TITLE
Added Medium version of serif, changed variables names

### DIFF
--- a/index.css
+++ b/index.css
@@ -21,139 +21,163 @@
   --text-size-step-6:  calc( var(--text-size-step-5)  * var(--scale-factor) );
   --text-size-step-7:  calc( var(--text-size-step-6)  * var(--scale-factor) );
 
-  --fontfamily-body-default: 'Halifax Regular', Tahoma, sans-serif;
-  --fontfamily-body: var(--fontfamily-body-custom, var(--fontfamily-body-default));
-  --fontfamily-display-default: 'FF Milo Serif Pro', Palatino, serif;
-  --fontfamily-display: var(--fontfamily-display-custom, var(--fontfamily-display-default));
+  --fontfamily-sans-default: 'Halifax Regular', Tahoma, sans-serif;
+  --fontfamily-sans: var(--fontfamily-sans-custom, var(--fontfamily-sans-default));
+  --fontfamily-serif-default: 'FF Milo Serif Pro', Palatino, serif;
+  --fontfamily-serif: var(--fontfamily-serif-custom, var(--fontfamily-serif-default));
 
   --text-line-height-basic: 1.4;
 
   /** Line heights **/
 
   /* Font: Halifax Regular */
-  --text-line-height-body-on-step-7  : 1.25;
-  --text-line-height-body-on-step-6  : 1.3;
-  --text-line-height-body-on-step-5  : 1.3;
-  --text-line-height-body-on-step-4  : 1.35;
-  --text-line-height-body-on-step-3  : 1.4;
-  --text-line-height-body-on-step-2  : 1.4;
-  --text-line-height-body-on-step-1  : 1.41;
-  --text-line-height-body-on-step-0  : 1.35;
-  --text-line-height-body-on-step--1 : 1.4;
-  --text-line-height-body-on-step--2 : 1.34;
+  --text-line-height-sans-on-step-7  : 1.25;
+  --text-line-height-sans-on-step-6  : 1.3;
+  --text-line-height-sans-on-step-5  : 1.3;
+  --text-line-height-sans-on-step-4  : 1.35;
+  --text-line-height-sans-on-step-3  : 1.4;
+  --text-line-height-sans-on-step-2  : 1.4;
+  --text-line-height-sans-on-step-1  : 1.41;
+  --text-line-height-sans-on-step-0  : 1.35;
+  --text-line-height-sans-on-step--1 : 1.4;
+  --text-line-height-sans-on-step--2 : 1.34;
 
   /* Font: Halifax Bold */
-  --text-line-height-body-bold-on-step-7  : 1.1;
-  --text-line-height-body-bold-on-step-6  : 1.17;
-  --text-line-height-body-bold-on-step-5  : 1.22;
-  --text-line-height-body-bold-on-step-4  : 1.23;
-  --text-line-height-body-bold-on-step-3  : 1.3;
-  --text-line-height-body-bold-on-step-2  : 1.33;
-  --text-line-height-body-bold-on-step-1  : 1.3;
-  --text-line-height-body-bold-on-step-0  : 1.3;
-  --text-line-height-body-bold-on-step--1 : 1.28;
-  --text-line-height-body-bold-on-step--2 : 1.4;
+  --text-line-height-sans-bold-on-step-7  : 1.1;
+  --text-line-height-sans-bold-on-step-6  : 1.17;
+  --text-line-height-sans-bold-on-step-5  : 1.22;
+  --text-line-height-sans-bold-on-step-4  : 1.23;
+  --text-line-height-sans-bold-on-step-3  : 1.3;
+  --text-line-height-sans-bold-on-step-2  : 1.33;
+  --text-line-height-sans-bold-on-step-1  : 1.3;
+  --text-line-height-sans-bold-on-step-0  : 1.3;
+  --text-line-height-sans-bold-on-step--1 : 1.28;
+  --text-line-height-sans-bold-on-step--2 : 1.4;
 
   /* Font: Halifax Light */
-  --text-line-height-body-light-on-step-7  : 1.21;
-  --text-line-height-body-light-on-step-6  : 1.25;
-  --text-line-height-body-light-on-step-5  : 1.33;
-  --text-line-height-body-light-on-step-4  : 1.3;
-  --text-line-height-body-light-on-step-3  : 1.34;
-  --text-line-height-body-light-on-step-2  : 1.3;
-  --text-line-height-body-light-on-step-1  : 1.3;
-  --text-line-height-body-light-on-step-0  : 1.35;
-  --text-line-height-body-light-on-step--1 : 1.35;
-  --text-line-height-body-light-on-step--2 : 1.4;
+  --text-line-height-sans-light-on-step-7  : 1.21;
+  --text-line-height-sans-light-on-step-6  : 1.25;
+  --text-line-height-sans-light-on-step-5  : 1.33;
+  --text-line-height-sans-light-on-step-4  : 1.3;
+  --text-line-height-sans-light-on-step-3  : 1.34;
+  --text-line-height-sans-light-on-step-2  : 1.3;
+  --text-line-height-sans-light-on-step-1  : 1.3;
+  --text-line-height-sans-light-on-step-0  : 1.35;
+  --text-line-height-sans-light-on-step--1 : 1.35;
+  --text-line-height-sans-light-on-step--2 : 1.4;
 
   /* Font: Ff Milo Serif Pro Med Italic */
-  --text-line-height-display-italic-on-step-7  : 1.20;
-  --text-line-height-display-italic-on-step-6  : 1.23;
-  --text-line-height-display-italic-on-step-5  : 1.25;
-  --text-line-height-display-italic-on-step-4  : 1.25;
-  --text-line-height-display-italic-on-step-3  : 1.25;
-  --text-line-height-display-italic-on-step-2  : 1.26;
-  --text-line-height-display-italic-on-step-1  : 1.27;
-  --text-line-height-display-italic-on-step-0  : 1.27;
-  --text-line-height-display-italic-on-step--1 : 1.24;
-  --text-line-height-display-italic-on-step--2 : 1.25;
+  --text-line-height-serif-italic-on-step-7  : 1.20;
+  --text-line-height-serif-italic-on-step-6  : 1.23;
+  --text-line-height-serif-italic-on-step-5  : 1.25;
+  --text-line-height-serif-italic-on-step-4  : 1.25;
+  --text-line-height-serif-italic-on-step-3  : 1.25;
+  --text-line-height-serif-italic-on-step-2  : 1.26;
+  --text-line-height-serif-italic-on-step-1  : 1.27;
+  --text-line-height-serif-italic-on-step-0  : 1.27;
+  --text-line-height-serif-italic-on-step--1 : 1.24;
+  --text-line-height-serif-italic-on-step--2 : 1.25;
 
   /* Font: Ff Milo Serif Pro */
-  --text-line-height-display-on-step-7  : 1.18;
-  --text-line-height-display-on-step-6  : 1.26;
-  --text-line-height-display-on-step-5  : 1.27;
-  --text-line-height-display-on-step-4  : 1.33;
-  --text-line-height-display-on-step-3  : 1.36;
-  --text-line-height-display-on-step-2  : 1.37;
-  --text-line-height-display-on-step-1  : 1.37;
-  --text-line-height-display-on-step-0  : 1.4;
-  --text-line-height-display-on-step--1 : 1.38;
-  --text-line-height-display-on-step--2 : 1.38;
+  --text-line-height-serif-on-step-7  : 1.18;
+  --text-line-height-serif-on-step-6  : 1.26;
+  --text-line-height-serif-on-step-5  : 1.27;
+  --text-line-height-serif-on-step-4  : 1.33;
+  --text-line-height-serif-on-step-3  : 1.36;
+  --text-line-height-serif-on-step-2  : 1.37;
+  --text-line-height-serif-on-step-1  : 1.37;
+  --text-line-height-serif-on-step-0  : 1.4;
+  --text-line-height-serif-on-step--1 : 1.38;
+  --text-line-height-serif-on-step--2 : 1.38;
+
+  /* Font: FF Milo Serif OT Medium */
+  --text-line-height-serif-medium-on-step-7  : 1.20;
+  --text-line-height-serif-medium-on-step-6  : 1.23;
+  --text-line-height-serif-medium-on-step-5  : 1.25;
+  --text-line-height-serif-medium-on-step-4  : 1.25;
+  --text-line-height-serif-medium-on-step-3  : 1.25;
+  --text-line-height-serif-medium-on-step-2  : 1.26;
+  --text-line-height-serif-medium-on-step-1  : 1.27;
+  --text-line-height-serif-medium-on-step-0  : 1.27;
+  --text-line-height-serif-medium-on-step--1 : 1.24;
+  --text-line-height-serif-medium-on-step--2 : 1.25;
 
   /** Letter spacing **/
   /* Font: Halifax Regular */
-  --text-letter-spacing-body-on-step-7  : normal;
-  --text-letter-spacing-body-on-step-6  : normal;
-  --text-letter-spacing-body-on-step-5  : normal;
-  --text-letter-spacing-body-on-step-4  : normal;
-  --text-letter-spacing-body-on-step-3  : normal;
-  --text-letter-spacing-body-on-step-2  : normal;
-  --text-letter-spacing-body-on-step-1  : normal;
-  --text-letter-spacing-body-on-step-0  : normal;
-  --text-letter-spacing-body-on-step--1 : normal;
-  --text-letter-spacing-body-on-step--2 : normal;
+  --text--seri-sans-on-step-7  : normal;
+  --text-letter-spacing-sans-on-step-6  : normal;
+  --text-letter-spacing-sans-on-step-5  : normal;
+  --text-letter-spacing-sans-on-step-4  : normal;
+  --text-letter-spacing-sans-on-step-3  : normal;
+  --text-letter-spacing-sans-on-step-2  : normal;
+  --text-letter-spacing-sans-on-step-1  : normal;
+  --text-letter-spacing-sans-on-step-0  : normal;
+  --text-letter-spacing-sans-on-step--1 : normal;
+  --text-letter-spacing-sans-on-step--2 : normal;
 
   /* Font: Halifax Bold */
-  --text-letter-spacing-body-bold-on-step-7  : normal;
-  --text-letter-spacing-body-bold-on-step-6  : normal;
-  --text-letter-spacing-body-bold-on-step-5  : normal;
-  --text-letter-spacing-body-bold-on-step-4  : normal;
-  --text-letter-spacing-body-bold-on-step-3  : 0.003em;
-  --text-letter-spacing-body-bold-on-step-2  : normal;
-  --text-letter-spacing-body-bold-on-step-1  : normal;
-  --text-letter-spacing-body-bold-on-step-0  : normal;
-  --text-letter-spacing-body-bold-on-step--1 : normal;
-  --text-letter-spacing-body-bold-on-step--2 : normal;
+  --text-letter-spacing-sans-bold-on-step-7  : normal;
+  --text-letter-spacing-sans-bold-on-step-6  : normal;
+  --text-letter-spacing-sans-bold-on-step-5  : normal;
+  --text-letter-spacing-sans-bold-on-step-4  : normal;
+  --text-letter-spacing-sans-bold-on-step-3  : 0.003em;
+  --text-letter-spacing-sans-bold-on-step-2  : normal;
+  --text-letter-spacing-sans-bold-on-step-1  : normal;
+  --text-letter-spacing-sans-bold-on-step-0  : normal;
+  --text-letter-spacing-sans-bold-on-step--1 : normal;
+  --text-letter-spacing-sans-bold-on-step--2 : normal;
 
   /* Font: Halifax Light */
-  --text-letter-spacing-body-light-on-step-7  : normal;
-  --text-letter-spacing-body-light-on-step-6  : normal;
-  --text-letter-spacing-body-light-on-step-5  : normal;
-  --text-letter-spacing-body-light-on-step-4  : normal;
-  --text-letter-spacing-body-light-on-step-3  : normal;
-  --text-letter-spacing-body-light-on-step-2  : normal;
-  --text-letter-spacing-body-light-on-step-1  : normal;
-  --text-letter-spacing-body-light-on-step-0  : normal;
-  --text-letter-spacing-body-light-on-step--1 : 0.015em;
-  --text-letter-spacing-body-light-on-step--2 : 0.015em;
+  --text-letter-spacing-sans-light-on-step-7  : normal;
+  --text-letter-spacing-sans-light-on-step-6  : normal;
+  --text-letter-spacing-sans-light-on-step-5  : normal;
+  --text-letter-spacing-sans-light-on-step-4  : normal;
+  --text-letter-spacing-sans-light-on-step-3  : normal;
+  --text-letter-spacing-sans-light-on-step-2  : normal;
+  --text-letter-spacing-sans-light-on-step-1  : normal;
+  --text-letter-spacing-sans-light-on-step-0  : normal;
+  --text-letter-spacing-sans-light-on-step--1 : 0.015em;
+  --text-letter-spacing-sans-light-on-step--2 : 0.015em;
 
   /* Font: Ff Milo Serif Pro Med Italic */
-  --text-letter-spacing-display-italic-on-step-7  : normal;
-  --text-letter-spacing-display-italic-on-step-6  : normal;
-  --text-letter-spacing-display-italic-on-step-5  : normal;
-  --text-letter-spacing-display-italic-on-step-4  : normal;
-  --text-letter-spacing-display-italic-on-step-3  : normal;
-  --text-letter-spacing-display-italic-on-step-2  : normal;
-  --text-letter-spacing-display-italic-on-step-1  : normal;
-  --text-letter-spacing-display-italic-on-step-0  : normal;
-  --text-letter-spacing-display-italic-on-step--1 : normal;
-  --text-letter-spacing-display-italic-on-step--2 : normal;
+  --text-letter-spacing-serif-italic-on-step-7  : normal;
+  --text-letter-spacing-serif-italic-on-step-6  : normal;
+  --text-letter-spacing-serif-italic-on-step-5  : normal;
+  --text-letter-spacing-serif-italic-on-step-4  : normal;
+  --text-letter-spacing-serif-italic-on-step-3  : normal;
+  --text-letter-spacing-serif-italic-on-step-2  : normal;
+  --text-letter-spacing-serif-italic-on-step-1  : normal;
+  --text-letter-spacing-serif-italic-on-step-0  : normal;
+  --text-letter-spacing-serif-italic-on-step--1 : normal;
+  --text-letter-spacing-serif-italic-on-step--2 : normal;
 
   /* Font: Ff Milo Serif Pro */
-  --text-letter-spacing-display-on-step-7  : normal;
-  --text-letter-spacing-display-on-step-6  : normal;
-  --text-letter-spacing-display-on-step-5  : normal;
-  --text-letter-spacing-display-on-step-4  : normal;
-  --text-letter-spacing-display-on-step-3  : normal;
-  --text-letter-spacing-display-on-step-2  : normal;
-  --text-letter-spacing-display-on-step-1  : normal;
-  --text-letter-spacing-display-on-step-0  : normal;
-  --text-letter-spacing-display-on-step--1 : normal;
-  --text-letter-spacing-display-on-step--2 : normal;
+  --text-letter-spacing-serif-on-step-7  : normal;
+  --text-letter-spacing-serif-on-step-6  : normal;
+  --text-letter-spacing-serif-on-step-5  : normal;
+  --text-letter-spacing-serif-on-step-4  : normal;
+  --text-letter-spacing-serif-on-step-3  : normal;
+  --text-letter-spacing-serif-on-step-2  : normal;
+  --text-letter-spacing-serif-on-step-1  : normal;
+  --text-letter-spacing-serif-on-step-0  : normal;
+  --text-letter-spacing-serif-on-step--1 : normal;
+  --text-letter-spacing-serif-on-step--2 : normal;
+
+  /* Font: FF Milo Serif OT Medium */
+  --text-letter-spacing-serif-medium-on-step-7  : normal;
+  --text-letter-spacing-serif-medium-on-step-6  : normal;
+  --text-letter-spacing-serif-medium-on-step-5  : normal;
+  --text-letter-spacing-serif-medium-on-step-4  : normal;
+  --text-letter-spacing-serif-medium-on-step-3  : normal;
+  --text-letter-spacing-serif-medium-on-step-2  : -0.020em;
+  --text-letter-spacing-serif-medium-on-step-1  : normal;
+  --text-letter-spacing-serif-medium-on-step-0  : normal;
+  --text-letter-spacing-serif-medium-on-step--1 : normal;
+  --text-letter-spacing-serif-medium-on-step--2 : normal;
 }
 
 html {
-  line-height: var(--text-line-height-body-on-step-0);
+  line-height: var(--text-line-height-sans-on-step-0);
   font-size: 18px;
 }
 

--- a/index.css
+++ b/index.css
@@ -164,16 +164,16 @@
   --text-letter-spacing-serif-on-step--2 : normal;
 
   /* Font: FF Milo Serif OT Medium */
-  --text-letter-spacing-serif-medium-on-step-7  : normal;
-  --text-letter-spacing-serif-medium-on-step-6  : normal;
-  --text-letter-spacing-serif-medium-on-step-5  : normal;
-  --text-letter-spacing-serif-medium-on-step-4  : normal;
-  --text-letter-spacing-serif-medium-on-step-3  : normal;
+  --text-letter-spacing-serif-medium-on-step-7  : -0.020em;
+  --text-letter-spacing-serif-medium-on-step-6  : -0.020em;
+  --text-letter-spacing-serif-medium-on-step-5  : -0.020em;
+  --text-letter-spacing-serif-medium-on-step-4  : -0.020em;
+  --text-letter-spacing-serif-medium-on-step-3  : -0.020em;
   --text-letter-spacing-serif-medium-on-step-2  : -0.020em;
-  --text-letter-spacing-serif-medium-on-step-1  : normal;
-  --text-letter-spacing-serif-medium-on-step-0  : normal;
-  --text-letter-spacing-serif-medium-on-step--1 : normal;
-  --text-letter-spacing-serif-medium-on-step--2 : normal;
+  --text-letter-spacing-serif-medium-on-step-1  : -0.020em;
+  --text-letter-spacing-serif-medium-on-step-0  : -0.020em;
+  --text-letter-spacing-serif-medium-on-step--1 : -0.020em;
+  --text-letter-spacing-serif-medium-on-step--2 : -0.020em;
 }
 
 html {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-typography",
-  "version": "1.5.3",
+  "version": "2.0.0",
   "description": "Typography component containing postCSS variables for font sizes and line-heights for each font size. Uses a major second modular scale.",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",


### PR DESCRIPTION
The assumption to have 1 font-family for the displays and 1 font-family for the body has been destroyed by the designers team so I think that refer to sans or serif instead that body and display will simplify the dev part of styling  and it will be less confusing.