### PR TITLE
WP-1486 prepare for react 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - '4'
+  - '6'
   - stable
 after_success: >-
   travis-after-all && npm run semantic-release && npm run pages -- --repo

--- a/package.json
+++ b/package.json
@@ -130,6 +130,9 @@
       "stylelint-config-strict"
     ]
   },
+  "peerDependencies": {
+    "react": "^0.14.8||^15.0.0||^16.0.0"
+  },
   "devDependencies": {
     "@economist/doc-pack": "^1.0.7",
     "@economist/provision-react-component": "3.0.3",
@@ -144,10 +147,8 @@
     "browserify": "^13.0.1",
     "browserify-istanbul": "^2.0.0",
     "chai": "^3.5.0",
-    "chai-enzyme": "^0.4.2",
     "chai-spies": "^0.7.1",
     "coveralls": "^2.11.9",
-    "enzyme": "^2.2.0",
     "eslint": "^2.9.0",
     "eslint-config-strict": "^8.5.1",
     "eslint-config-strict-react": "^8.0.1",
@@ -176,11 +177,10 @@
     "postcss-import": "^8.1.2",
     "postcss-reporter": "^1.3.3",
     "postcss-url": "^5.1.2",
-    "react": "^0.14.8||^15.0.0",
-    "react-addons-test-utils": "^0.14.8||^15.0.0",
-    "react-dom": "^0.14.8||^15.0.0",
-    "react-tab-panel": "^2.2.0",
-    "react-test-renderer": "^15.5.4",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "react-tabs": "^2.1.0",
+    "react-test-renderer": "^16.0.0",
     "semantic-release": "^4.3.5",
     "stylelint": "^6.3.3",
     "stylelint-config-strict": "^5.0.0",

--- a/src/example.css
+++ b/src/example.css
@@ -2,7 +2,7 @@
 /* step classes do not match the desired pattern! */
 
 @import 'index.css';
-@import 'react-tab-panel';
+@import 'react-tabs/style/react-tabs.css';
 
 .library--example-tabs {
   font-size: 20px;

--- a/src/example.js
+++ b/src/example.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import SampleText from './sampletext';
-import TabPanel from 'react-tab-panel';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 
 const fonts = [
   [ 'sans', '300', '', 'EconSans' ],
@@ -18,36 +18,52 @@ const fonts = [
   [ 'sans', '500', '', 'EconSansCnd' ],
   [ 'sans', '700', '', 'EconSansCnd' ],
 ];
-const panels = fonts.map((fontFamily) => {
-  const [ kind, modifier, fontStyle, family ] = fontFamily;
-  const classes = [
-    `example__${ kind }-text`,
-    modifier && `example__${ kind }-text--${ modifier }`,
-  ].join(' ');
-  const style = { fontFamily: family };
-  if (modifier !== '') {
-    style.fontWeight = modifier;
-  }
-  if (fontStyle !== '') {
-    style.fontStyle = fontStyle;
-  }
-  return (
-    <div
-      tabTitle={`${ family } ${ modifier } ${ fontStyle }`}
-      key={`panel-typography-${ fontFamily.join('x') }`}
-    >
-      <h2>Sample for font-family: {fontFamily.join(' ')}</h2>
-      <div
-        className={classes}
-        style={style}
-        data-font={family.toLowerCase().replace(/ /g, '-')}
-      ><SampleText /></div>
-      <hr />
-    </div>
-  );
-});
+const tabPanels = fonts
+  .map((fontFamily) => {
+    const [ kind, modifier, fontStyle, family ] = fontFamily;
+    const classes = [
+      `example__${ kind }-text`,
+      modifier && `example__${ kind }-text--${ modifier }`,
+    ].join(' ');
+    const style = { fontFamily: family };
+    if (modifier !== '') {
+      style.fontWeight = modifier;
+    }
+    if (fontStyle !== '') {
+      style.fontStyle = fontStyle;
+    }
+
+    return {
+      key: `panel-typography-${ fontFamily.join('x') }`,
+      title: `${ family } ${ modifier } ${ fontStyle }`,
+      classes,
+      style,
+      family,
+      fontFamily,
+    };
+  })
+  .reduce((result, config) => {
+    result.tabs.push(
+      <Tab key={config.key}>{config.title}</Tab>
+    );
+    result.panels.push(
+      <TabPanel key={config.key}>
+        <h2>Sample for font-family: {config.fontFamily.join(' ')}</h2>
+        <div
+          className={config.classes}
+          style={config.style}
+          data-font={config.family.toLowerCase().replace(/ /g, '-')}
+        ><SampleText /></div>
+      </TabPanel>
+    );
+
+    return result;
+  }, { tabs: [], panels: [] });
 export default (
-  <TabPanel>
-    {panels}
-  </TabPanel>
+  <Tabs>
+    <TabList>
+      {tabPanels.tabs}
+    </TabList>
+    {tabPanels.panels}
+  </Tabs>
 );

--- a/src/sampletext.js
+++ b/src/sampletext.js
@@ -33,11 +33,12 @@ function stepFromClass(className) {
 function addModularScaleTitles(elm) {
   const scaleFactor = 20;
   return React.cloneElement(elm, {
-    children: elm.props.children.map((child) => {
+    children: elm.props.children.map((child, index) => {
       const step = stepFromClass(child.props.className || '') || 0;
       const emSize = modularScale(step);
       return React.cloneElement(child, {
         title: `${ roundThree(emSize) }em (${ roundOne(emSize * scaleFactor) }px)`,
+        key: index,
       });
     }),
   });

--- a/test/index.js
+++ b/test/index.js
@@ -2,8 +2,7 @@ import 'babel-polyfill';
 import React from 'react';
 import Typography from '../src';
 import chai from 'chai';
-import chaiEnzyme from 'chai-enzyme';
-chai.use(chaiEnzyme()).should();
+chai.should();
 describe('Typography', () => {
   it('renders a React element', () => {
     React.isValidElement(<Typography />).should.equal(true);


### PR DESCRIPTION
A few notes from me:

- `enzyme` and `chai-enzyme` not used, hence removed from dev deps
- The example relied on `react-tab-panel` which seems no longer maintained (GitHub repo be gone!) and is guilty of `React.PropTypes`, so I had to find an alternative.
- React was complaining about missing key prop in the example, so I had to add it (sampletext.js). I'm using array index for the key, which is not the best, however there is no better key readily available and this is simply example, not the application, so I don't believe we should worry about that.
