### PR TITLE
WP-1214 Adding font-display: swap to font-face.css for delayed font re-render update

### DIFF
--- a/src/font-face.css
+++ b/src/font-face.css
@@ -3,157 +3,157 @@
 
 @font-face {
   font-family: EconSans;
+  font-display: swap;
   font-weight: 300;
   src:
     url('/assets/econsans-subset-lt.woff2') format('woff2'),
     url('/assets/econsans-subset-lt.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: EconSans;
+  font-display: swap;
   font-style: normal;
   src:
     url('/assets/econsans-subset-rg.woff2') format('woff2'),
     url('/assets/econsans-subset-rg.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: EconSans;
+  font-display: swap;
   font-style: italic;
   src:
     url('/assets/econsans-subset-it.woff2') format('woff2'),
     url('/assets/econsans-subset-it.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: EconSans;
+  font-display: swap;
   font-weight: 500;
   src:
     url('/assets/econsans-subset-md.woff2') format('woff2'),
     url('/assets/econsans-subset-md.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: EconSans;
+  font-display: swap;
   font-weight: 700;
   src:
     url('/assets/econsans-subset-bd.woff2') format('woff2'),
     url('/assets/econsans-subset-bd.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: MiloSerifPro;
+  font-display: swap;
   font-style: normal;
   src:
     url('/assets/milo-subset-rg.woff2') format('woff2'),
     url('/assets/milo-subset-rg.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: MiloSerifPro;
+  font-display: swap;
   font-style: italic;
   src:
     url('/assets/milo-subset-it.woff2') format('woff2'),
     url('/assets/milo-subset-it.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: MiloSerifPro;
+  font-display: swap;
   font-weight: 500;
   src:
     url('/assets/milo-subset-md.woff2') format('woff2'),
     url('/assets/milo-subset-md.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: MiloSerifPro;
+  font-display: swap;
   font-weight: 700;
   src:
     url('/assets/milo-subset-bd.woff2') format('woff2'),
     url('/assets/milo-subset-bd.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: EconSansCnd;
+  font-display: swap;
   font-weight: 300;
   src:
     url('/assets/econsans-subset-cd-li.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-li.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: EconSansCnd;
   font-style: italic;
+  font-display: swap;
   font-weight: 300;
   src:
     url('/assets/econsans-subset-cd-li-it.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-li-it.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: EconSansCnd;
+  font-display: swap;
   font-weight: normal;
   src:
     url('/assets/econsans-subset-cd-rg.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-rg.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: EconSansCnd;
   font-style: italic;
+  font-display: swap;
   font-weight: normal;
   src:
     url('/assets/econsans-subset-cd-it.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-it.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: EconSansCnd;
+  font-display: swap;
   font-weight: 500;
   src:
     url('/assets/econsans-subset-cd-md.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-md.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: EconSansCnd;
   font-style: italic;
+  font-display: swap;
   font-weight: 500;
   src:
     url('/assets/econssans-cd-md-it.woff2') format('woff2'),
     url('/assets/econssans-cd-md-it.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: EconSansCnd;
+  font-display: swap;
   font-weight: 700;
   src:
     url('/assets/econsans-subset-cd-bd.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-bd.woff') format('woff');
-  font-display: swap;
 }
 
 @font-face {
   font-family: EconSansCnd;
   font-style: italic;
+  font-display: swap;
   font-weight: 700;
   src:
     url('/assets/econsans-subset-cd-bd-it.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-bd-it.woff') format('woff');
-  font-display: swap;
 }

--- a/src/font-face.css
+++ b/src/font-face.css
@@ -2,8 +2,8 @@
 /* too many components refer to EconSans */
 
 @font-face {
-  font-family: EconSans;
   font-display: swap;
+  font-family: EconSans;
   font-weight: 300;
   src:
     url('/assets/econsans-subset-lt.woff2') format('woff2'),
@@ -11,8 +11,8 @@
 }
 
 @font-face {
-  font-family: EconSans;
   font-display: swap;
+  font-family: EconSans;
   font-style: normal;
   src:
     url('/assets/econsans-subset-rg.woff2') format('woff2'),
@@ -20,8 +20,8 @@
 }
 
 @font-face {
-  font-family: EconSans;
   font-display: swap;
+  font-family: EconSans;
   font-style: italic;
   src:
     url('/assets/econsans-subset-it.woff2') format('woff2'),
@@ -29,8 +29,8 @@
 }
 
 @font-face {
-  font-family: EconSans;
   font-display: swap;
+  font-family: EconSans;
   font-weight: 500;
   src:
     url('/assets/econsans-subset-md.woff2') format('woff2'),
@@ -38,8 +38,8 @@
 }
 
 @font-face {
-  font-family: EconSans;
   font-display: swap;
+  font-family: EconSans;
   font-weight: 700;
   src:
     url('/assets/econsans-subset-bd.woff2') format('woff2'),
@@ -47,8 +47,8 @@
 }
 
 @font-face {
-  font-family: MiloSerifPro;
   font-display: swap;
+  font-family: MiloSerifPro;
   font-style: normal;
   src:
     url('/assets/milo-subset-rg.woff2') format('woff2'),
@@ -56,8 +56,8 @@
 }
 
 @font-face {
-  font-family: MiloSerifPro;
   font-display: swap;
+  font-family: MiloSerifPro;
   font-style: italic;
   src:
     url('/assets/milo-subset-it.woff2') format('woff2'),
@@ -65,8 +65,8 @@
 }
 
 @font-face {
-  font-family: MiloSerifPro;
   font-display: swap;
+  font-family: MiloSerifPro;
   font-weight: 500;
   src:
     url('/assets/milo-subset-md.woff2') format('woff2'),
@@ -74,8 +74,8 @@
 }
 
 @font-face {
-  font-family: MiloSerifPro;
   font-display: swap;
+  font-family: MiloSerifPro;
   font-weight: 700;
   src:
     url('/assets/milo-subset-bd.woff2') format('woff2'),
@@ -83,8 +83,8 @@
 }
 
 @font-face {
-  font-family: EconSansCnd;
   font-display: swap;
+  font-family: EconSansCnd;
   font-weight: 300;
   src:
     url('/assets/econsans-subset-cd-li.woff2') format('woff2'),
@@ -93,8 +93,8 @@
 
 @font-face {
   font-family: EconSansCnd;
-  font-style: italic;
   font-display: swap;
+  font-style: italic;
   font-weight: 300;
   src:
     url('/assets/econsans-subset-cd-li-it.woff2') format('woff2'),
@@ -102,8 +102,8 @@
 }
 
 @font-face {
-  font-family: EconSansCnd;
   font-display: swap;
+  font-family: EconSansCnd;
   font-weight: normal;
   src:
     url('/assets/econsans-subset-cd-rg.woff2') format('woff2'),
@@ -112,8 +112,8 @@
 
 @font-face {
   font-family: EconSansCnd;
-  font-style: italic;
   font-display: swap;
+  font-style: italic;
   font-weight: normal;
   src:
     url('/assets/econsans-subset-cd-it.woff2') format('woff2'),
@@ -121,8 +121,8 @@
 }
 
 @font-face {
-  font-family: EconSansCnd;
   font-display: swap;
+  font-family: EconSansCnd;
   font-weight: 500;
   src:
     url('/assets/econsans-subset-cd-md.woff2') format('woff2'),
@@ -131,8 +131,8 @@
 
 @font-face {
   font-family: EconSansCnd;
-  font-style: italic;
   font-display: swap;
+  font-style: italic;
   font-weight: 500;
   src:
     url('/assets/econssans-cd-md-it.woff2') format('woff2'),
@@ -140,8 +140,8 @@
 }
 
 @font-face {
-  font-family: EconSansCnd;
   font-display: swap;
+  font-family: EconSansCnd;
   font-weight: 700;
   src:
     url('/assets/econsans-subset-cd-bd.woff2') format('woff2'),
@@ -150,8 +150,8 @@
 
 @font-face {
   font-family: EconSansCnd;
-  font-style: italic;
   font-display: swap;
+  font-style: italic;
   font-weight: 700;
   src:
     url('/assets/econsans-subset-cd-bd-it.woff2') format('woff2'),

--- a/src/font-face.css
+++ b/src/font-face.css
@@ -7,6 +7,7 @@
   src:
     url('/assets/econsans-subset-lt.woff2') format('woff2'),
     url('/assets/econsans-subset-lt.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -15,6 +16,7 @@
   src:
     url('/assets/econsans-subset-rg.woff2') format('woff2'),
     url('/assets/econsans-subset-rg.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -23,6 +25,7 @@
   src:
     url('/assets/econsans-subset-it.woff2') format('woff2'),
     url('/assets/econsans-subset-it.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -31,6 +34,7 @@
   src:
     url('/assets/econsans-subset-md.woff2') format('woff2'),
     url('/assets/econsans-subset-md.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -39,6 +43,7 @@
   src:
     url('/assets/econsans-subset-bd.woff2') format('woff2'),
     url('/assets/econsans-subset-bd.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -47,6 +52,7 @@
   src:
     url('/assets/milo-subset-rg.woff2') format('woff2'),
     url('/assets/milo-subset-rg.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -55,6 +61,7 @@
   src:
     url('/assets/milo-subset-it.woff2') format('woff2'),
     url('/assets/milo-subset-it.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -63,6 +70,7 @@
   src:
     url('/assets/milo-subset-md.woff2') format('woff2'),
     url('/assets/milo-subset-md.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -71,6 +79,7 @@
   src:
     url('/assets/milo-subset-bd.woff2') format('woff2'),
     url('/assets/milo-subset-bd.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -79,6 +88,7 @@
   src:
     url('/assets/econsans-subset-cd-li.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-li.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -88,6 +98,7 @@
   src:
     url('/assets/econsans-subset-cd-li-it.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-li-it.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -96,6 +107,7 @@
   src:
     url('/assets/econsans-subset-cd-rg.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-rg.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -105,6 +117,7 @@
   src:
     url('/assets/econsans-subset-cd-it.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-it.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -113,6 +126,7 @@
   src:
     url('/assets/econsans-subset-cd-md.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-md.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -122,6 +136,7 @@
   src:
     url('/assets/econssans-cd-md-it.woff2') format('woff2'),
     url('/assets/econssans-cd-md-it.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -130,6 +145,7 @@
   src:
     url('/assets/econsans-subset-cd-bd.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-bd.woff') format('woff');
+  font-display: swap;
 }
 
 @font-face {
@@ -139,4 +155,5 @@
   src:
     url('/assets/econsans-subset-cd-bd-it.woff2') format('woff2'),
     url('/assets/econsans-subset-cd-bd-it.woff') format('woff');
+  font-display: swap;
 }

--- a/src/font-face.css
+++ b/src/font-face.css
@@ -92,8 +92,8 @@
 }
 
 @font-face {
-  font-family: EconSansCnd;
   font-display: swap;
+  font-family: EconSansCnd;
   font-style: italic;
   font-weight: 300;
   src:
@@ -111,8 +111,8 @@
 }
 
 @font-face {
-  font-family: EconSansCnd;
   font-display: swap;
+  font-family: EconSansCnd;
   font-style: italic;
   font-weight: normal;
   src:
@@ -130,8 +130,8 @@
 }
 
 @font-face {
-  font-family: EconSansCnd;
   font-display: swap;
+  font-family: EconSansCnd;
   font-style: italic;
   font-weight: 500;
   src:
@@ -149,8 +149,8 @@
 }
 
 @font-face {
-  font-family: EconSansCnd;
   font-display: swap;
+  font-family: EconSansCnd;
   font-style: italic;
   font-weight: 700;
   src:


### PR DESCRIPTION
## The purpose 
Display any(?) text based content as **asap** as possible.

## The ticket
[WP-1214](https://jira.economist.com/browse/WP-1214)

## The background
[https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display)

## The expected output
**GIVEN** I am a User
**WHEN** I go to the website
**THEN** I see the text content asap even if the web fonts are not loaded

## Comparison
See the difference in the text rendering
### live website (without font-display: swap)
_text visible after the fonts are fully loaded_
![page_render__live__without_font-display_swap](https://user-images.githubusercontent.com/419110/34572337-10ccefc6-f169-11e7-9be0-3494a0a3429d.gif)
### localhost website (with font-display: swap manually edited in node_modules font-face.css file)
_text visible instantly with (fallback/default) fonts rendering upfront_
![page_render__localhost__with_font-display_swap](https://user-images.githubusercontent.com/419110/34572384-297a1396-f169-11e7-8cdc-b4120b1932ac.gif)

 ## The burden
None (debatable)
  
  
  
  